### PR TITLE
add RWD to MenuBar - 14

### DIFF
--- a/src/components/features/ProductSearch/ProductSearch.js
+++ b/src/components/features/ProductSearch/ProductSearch.js
@@ -13,7 +13,6 @@ const ProductSearch = () => (
       <select className={styles.categorySelect} name='' id=''>
         <option value=''>Select a category</option>
       </select>
-      */}
       <ol>
         <li>
           Select a category

--- a/src/components/features/ProductSearch/ProductSearch.js
+++ b/src/components/features/ProductSearch/ProductSearch.js
@@ -10,8 +10,7 @@ const ProductSearch = () => (
   <form action='' className={styles.root}>
     <div className={styles.category}>
       <FontAwesomeIcon className={styles.icon} icon={faListUl} />
-      {/*
-      <select name='' id=''>
+      <select className={styles.categorySelect} name='' id=''>
         <option value=''>Select a category</option>
       </select>
       */}
@@ -37,9 +36,13 @@ const ProductSearch = () => (
       <FontAwesomeIcon className={styles.icon} icon={faCaretDown} />
     </div>
     <div className={styles.searchField}>
-      <input placeholder='Search products...' type='text' />
-      <button>
-        <FontAwesomeIcon className={styles.icon} icon={faSearch} />
+      <input
+        className={styles.searchInput}
+        placeholder='Search products...'
+        type='text'
+      />
+      <button className={styles.icon}>
+        <FontAwesomeIcon icon={faSearch} />
       </button>
     </div>
   </form>

--- a/src/components/features/ProductSearch/ProductSearch.module.scss
+++ b/src/components/features/ProductSearch/ProductSearch.module.scss
@@ -109,7 +109,7 @@
       padding: 5px 30px 5px 35px;
       font-size: 12px;
       position: relative;
-      z-index: 1;
+      z-index: 0;
     }
 
     select:focus {
@@ -154,4 +154,34 @@
     background-color: $productbox-content-text;
     color: $productbox-sale-text ;
   }
+}
+
+/*MEDIA QUERIES*/
+
+@media (min-width: 320px) and (max-width: 490px){
+  .root {
+
+    .category{
+      max-width: 70px;
+      //overflow-wrap: break-word;
+    }
+
+    .categorySelect {
+      max-width: 30px;
+    }
+
+    .searchField {
+      max-width: 70px;
+      position: relative;
+    }
+
+    .icon {
+      position: absolute;
+    }
+
+    .searchInput {
+      visibility: hidden;
+    }
+  }
+
 }

--- a/src/components/layout/MenuBar/MenuBar.js
+++ b/src/components/layout/MenuBar/MenuBar.js
@@ -5,47 +5,77 @@ import ProductSearch from '../../features/ProductSearch/ProductSearch';
 
 import styles from './MenuBar.module.scss';
 
-const MenuBar = ({ children }) => (
-  <div className={styles.root}>
-    <div className='container'>
-      <div className='row align-items-center'>
-        <div className='col'>
-          <ProductSearch />
-        </div>
-        <div className={'col-auto ' + styles.menu}>
-          <ul>
-            <li>
-              <a href='/#' className={styles.active}>
-                Home
-              </a>
-            </li>
-            <li>
-              <a href='/#'>Furniture</a>
-            </li>
-            <li>
-              <a href='/#'>Chair</a>
-            </li>
-            <li>
-              <a href='/#'>Table</a>
-            </li>
-            <li>
-              <a href='/#'>Sofa</a>
-            </li>
-            <li>
-              <a href='/#'>Bedroom</a>
-            </li>
-            <li>
-              <a href='/#'>Blog</a>
-            </li>
-          </ul>
+class MenuBar extends React.Component {
+  static propTypes = {
+    children: PropTypes.node,
+  };
+
+  constructor(props) {
+    super(props);
+    this.toggleClass = this.toggleClass.bind(this);
+    this.state = {
+      active: false,
+    };
+  }
+
+  toggleClass() {
+    const currentState = this.state.active;
+    this.setState({ active: !currentState });
+  }
+
+  render() {
+    return (
+      <div className={styles.root}>
+        <div className={'container' + ' ' + styles.container}>
+          <div className={'row align-items-center' + ' ' + styles.divContainer}>
+            <div className={'col' + ' ' + styles.productSearch}>
+              <ProductSearch />
+              {/*className={this.state.active ? 'active' : null}*/}
+              <button
+                id={styles.hamburgerMenu}
+                className={this.state.active ? 'active' : null}
+                onClick={this.toggleClass}
+              >
+                <span className={styles.hamburgerBox}>
+                  <span className={styles.hamburgerInner}></span>
+                </span>
+              </button>
+            </div>
+            <div
+              id={this.state.active ? 'active' : null}
+              className={'col-auto ' + styles.menu}
+            >
+              <ul>
+                <li>
+                  <a href='/#' className={styles.active}>
+                    Home
+                  </a>
+                </li>
+                <li>
+                  <a href='/#'>Furniture</a>
+                </li>
+                <li>
+                  <a href='/#'>Chair</a>
+                </li>
+                <li>
+                  <a href='/#'>Table</a>
+                </li>
+                <li>
+                  <a href='/#'>Sofa</a>
+                </li>
+                <li>
+                  <a href='/#'>Bedroom</a>
+                </li>
+                <li>
+                  <a href='/#'>Blog</a>
+                </li>
+              </ul>
+            </div>
+          </div>
         </div>
       </div>
-    </div>
-  </div>
-);
-
-MenuBar.propTypes = {
-  children: PropTypes.node,
-};
+    );
+  }
+}
 
 export default MenuBar;

--- a/src/components/layout/MenuBar/MenuBar.js
+++ b/src/components/layout/MenuBar/MenuBar.js
@@ -30,7 +30,6 @@ class MenuBar extends React.Component {
           <div className={'row align-items-center' + ' ' + styles.divContainer}>
             <div className={'col' + ' ' + styles.productSearch}>
               <ProductSearch />
-              {/*className={this.state.active ? 'active' : null}*/}
               <button
                 id={styles.hamburgerMenu}
                 className={this.state.active ? 'active' : null}

--- a/src/components/layout/MenuBar/MenuBar.module.scss
+++ b/src/components/layout/MenuBar/MenuBar.module.scss
@@ -6,9 +6,79 @@
   background-color: $menubar-bg;
 
   :global(.container) > :global(.row) {
-    height: 84px;
+    min-height: 84px;
   }
 
+  /*HAMBURGER MENU*/
+  #hamburgerMenu {
+    padding: 15px;
+    display: inline-block;
+    position: relative;
+    cursor: pointer;
+    background-color: transparent;
+    border: 0;
+    margin: 0;
+    outline: none;
+  }
+
+  #hamburgerMenu .hamburgerBox {
+    width: 40px;
+    height: 24px;
+    display: inline-block;
+    position: relative;
+  }
+
+  @mixin hamburgerLine {
+    width: 100%;
+    height: 3px;
+    background-color: $topbar-link-hover;
+    position: absolute;
+  }
+
+  #hamburgerMenu .hamburgerInner{
+    @include hamburgerLine;
+
+    left: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    transition: $transition-translation;
+  }
+
+  #hamburgerMenu .hamburgerInner::before,
+  #hamburgerMenu .hamburgerInner::after {
+    @include hamburgerLine;
+    content: '';
+    left: 0;
+
+    transition: transform $transition-translation;
+  }
+
+  #hamburgerMenu .hamburgerInner::before{
+    top: -10px;
+  }
+
+  #hamburgerMenu .hamburgerInner::after {
+    top: 10px;
+  }
+
+  #hamburgerMenu[class~="active"] .hamburgerInner {
+    background-color: transparent;
+  }
+
+  #hamburgerMenu[class~="active"] .hamburgerInner:before {
+    transform: translateY(10px) rotate(45deg);
+  }
+
+  #hamburgerMenu[class~="active"] .hamburgerInner:after {
+    transform: translateY(-10px) rotate(-45deg);
+  }
+
+  #hamburgerMenu {
+    display: none;
+  }
+
+
+  /*MENU*/
   .menu {
     display: flex;
     align-self: stretch;
@@ -49,5 +119,74 @@
         border-color: $menubar-link-active-border;
       }
     }
+  }
+}
+
+/*MEDIA QUERIES*/
+@media (min-width: 769px) and (max-width:1200px) {
+  .root {
+    min-height: 130px;
+
+    .productSearch {
+      padding: 10px;
+    }
+
+    .menu {
+      padding-left: 10px;
+    }
+  }
+}
+
+@media (min-width: 320px) and (max-width: 768px){
+  .root {
+
+    .container {
+      padding: 0;
+    }
+
+    .divContainer {
+      margin: 0;
+    }
+
+    .productSearch {
+      padding: 10px;
+    }
+
+    .menu {
+      display: none;
+      width: 100%;
+    }
+
+    #hamburgerMenu {
+      display: inline-block;
+    }
+
+    .menu[id~="active"]{
+      width: 100%;
+      display:flex;
+      background-color: $menubar-bg;
+    }
+
+    .menu[id~="active"] ul{
+      display: flex;
+      flex-direction: column;
+      align-content: center;
+      align-items: center;
+      z-index: 2;
+      width: 100%;
+      background-color: $menubar-bg;
+    }
+
+    .menu[id~="active"] ul li {
+      background-color: $menubar-bg;
+    }
+
+    #hamburgerMenu[class~="active"] {
+      z-index: 3;
+      position: absolute;
+      right: 30px;
+      top: 5px;
+    }
+
   }
 }


### PR DESCRIPTION
Zrobiono : 
Na tabletach wyszukiwanie ma być pod menu, a na mniejszych ekranach ma być wyszukiwanie i obok niego ikona mobilnego menu, które po rozwinięciu ma pokazywać dropdown przykrywający treść strony. 