### PR TITLE
Add links to: main logo and buttons in MenuBar -73

### DIFF
--- a/src/components/layout/CompanyClaim/CompanyClaim.js
+++ b/src/components/layout/CompanyClaim/CompanyClaim.js
@@ -17,7 +17,7 @@ const CompanyClaim = () => (
           </p>
         </div>
         <div className={`col text-center ${styles.mobileLogo}`}>
-          <a href='/#'>
+          <a href='/'>
             <img src='/images/logo.png' alt='Bazar' />
           </a>
         </div>

--- a/src/components/layout/MenuBar/MenuBar.js
+++ b/src/components/layout/MenuBar/MenuBar.js
@@ -46,27 +46,27 @@ class MenuBar extends React.Component {
             >
               <ul>
                 <li>
-                  <a href='/#' className={styles.active}>
+                  <a href='/' className={styles.active}>
                     Home
                   </a>
                 </li>
                 <li>
-                  <a href='/#'>Furniture</a>
+                  <a href='/shop/furniture'>Furniture</a>
                 </li>
                 <li>
-                  <a href='/#'>Chair</a>
+                  <a href='/shop/chair'>Chair</a>
                 </li>
                 <li>
-                  <a href='/#'>Table</a>
+                  <a href='/shop/table'>Table</a>
                 </li>
                 <li>
-                  <a href='/#'>Sofa</a>
+                  <a href='/shop/sofa'>Sofa</a>
                 </li>
                 <li>
-                  <a href='/#'>Bedroom</a>
+                  <a href='/shop/bedroom'>Bedroom</a>
                 </li>
                 <li>
-                  <a href='/#'>Blog</a>
+                  <a href='/shop/blog'>Blog</a>
                 </li>
               </ul>
             </div>


### PR DESCRIPTION
WDP200801-73

zrobiono :

główne logo przenosi do strony głównej
przycisk w menu głównym HOME przenosi nas do strony głównej
przyciski w menu głównym (FURNITURE, CHAIR itd) przenoszą nas do podstrony shop z dodaniem swojej nazwy kategorii (z małych liter) do linku.
przykład: przycisk FURNITURE przenosi nas do /shop/furniture